### PR TITLE
Replace stand-in MockMPRLS classes 

### DIFF
--- a/tests/test_Collection.py
+++ b/tests/test_Collection.py
@@ -4,54 +4,20 @@ import sys
 sys.path.append('../')
 
 from pi.collection import Collection
+from pi.MPRLS import MockPressureSensorStatic
 
 class MockTank:
     """Mock Tank class to test Collection without real dependencies."""
     def __init__(self, name, pressure=50):
         self.name = name
         self.state = "CLOSED"
-        self.pressure_sensor = MockMPRLS(pressure)
+        self.pressure_sensor = MockPressureSensorStatic(pressure)
 
     def open(self):
         self.state = "OPEN"
 
     def close(self):
         self.state = "CLOSED"
-
-class MockMPRLS():
-    """Mock MPRLS class to simulate pressure readings for unit testing."""
-
-    def __init__(self, pressure):
-        self._pressure_value = pressure
-
-    def _get_pressure(self) -> float:
-        """Simulate getting a single pressure reading."""
-        return self._pressure_value
-
-    def _get_triple_pressure(self) -> float:
-        """Simulate getting a median of three pressure readings."""
-        return self._pressure_value  # Mocking behavior; real one would compute a median
-
-    def _set_pressure(self, value):
-        pass
-
-    def _del_pressure(self):
-        pass
-
-    # Define the properties to match the real class
-    pressure = property(
-        fget=_get_pressure,
-        fset=_set_pressure,
-        fdel=_del_pressure,
-        doc="The pressure of the MPRLS or -1 if it cannot be accessed"
-    )
-
-    triple_pressure = property(
-        fget=_get_triple_pressure,
-        fset=_set_pressure,
-        fdel=_del_pressure,
-        doc="The 3-sample median pressure of the MPRLS or -1 if it cannot be accessed"
-    )
 
 @pytest.fixture
 def mock_tank():

--- a/tests/test_MPRLS.py
+++ b/tests/test_MPRLS.py
@@ -9,6 +9,7 @@ from pi.MPRLS import MPRLSFile, MPRLSWrappedSensor, MockPressureSensorStatic, No
 
 # -----------------------------------------
 # Dummy implementations for MPRLSWrappedSensor tests
+# These simulate the behavior of adafruit_mprls.MPRLS
 # -----------------------------------------
 
 # A dummy sensor to simulate a working MPRLS sensor

--- a/tests/test_Tank.py
+++ b/tests/test_Tank.py
@@ -3,6 +3,7 @@ import pytest
 import sys
 sys.path.append('../')
 from pi.tank import Tank
+from pi.MPRLS import MockPressureSensorStatic
 
 class MockValve:
     """Mock Valve class to fully isolate Tank tests."""
@@ -20,27 +21,7 @@ class MockValve:
 @pytest.fixture
 def mock_mprls(monkeypatch):
     """Mock the MPRLS class."""
-    class MockMPRLS:
-        def __init__(self):
-            pass
-        
-        def _get_pressure(self):
-            return 50
-        
-        def _set_pressure(self, value):
-            pass
-        
-        def _del_pressure(self):
-            pass
-        
-        pressure = property(
-            fget=_get_pressure,
-            fset=_set_pressure,
-            fdel=_del_pressure,
-            doc="The pressure of the Pressure Sensor or -1 if it cannot be accessed"
-        )
-    
-    return MockMPRLS()
+    return MockPressureSensorStatic(pressure=50)
 
 def test_tank_initialization(mock_mprls):
     


### PR DESCRIPTION
Replace stand-in MockMPRLS classes with a new, standardized MockPressureSensorStatic class